### PR TITLE
Fix navigation handler bug and report icon

### DIFF
--- a/index-simple.html
+++ b/index-simple.html
@@ -114,7 +114,7 @@
                             Sync Data
                         </button>
                         <button class="action-btn">
-                            <i class="fas fa-report"></i>
+                            <i class="fas fa-file-lines"></i>
                             Generate Report
                         </button>
                     </div>

--- a/test.html
+++ b/test.html
@@ -59,9 +59,9 @@
     <h1>RepairBridge Platform Test</h1>
     <div class="container">
         <div class="nav">
-            <button class="active" onclick="showContent('dashboard')">Dashboard</button>
-            <button onclick="showContent('data')">Data Hub</button>
-            <button onclick="showContent('diagnostics')">Diagnostics</button>
+            <button class="active" onclick="showContent('dashboard', this)">Dashboard</button>
+            <button onclick="showContent('data', this)">Data Hub</button>
+            <button onclick="showContent('diagnostics', this)">Diagnostics</button>
         </div>
         <div class="content" id="content">
             <h2>Dashboard</h2>
@@ -71,16 +71,16 @@
     </div>
 
     <script>
-        function showContent(section) {
+        function showContent(section, button) {
             const content = document.getElementById('content');
             const buttons = document.querySelectorAll('.nav button');
-            
+
             // Remove active class from all buttons
             buttons.forEach(btn => btn.classList.remove('active'));
-            
+
             // Add active class to clicked button
-            event.target.classList.add('active');
-            
+            button.classList.add('active');
+
             // Update content based on section
             switch(section) {
                 case 'dashboard':


### PR DESCRIPTION
## Summary
- Pass clicked buttons to `showContent` in test page to avoid relying on non-standard `event`
- Replace invalid Font Awesome class `fa-report` with `fa-file-lines`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check /tmp/test-inline.js`


------
https://chatgpt.com/codex/tasks/task_e_689434b1a3688325b64416a1ed0f78c6