### PR TITLE
Preserve units in real-time data updates

### DIFF
--- a/script.js
+++ b/script.js
@@ -317,13 +317,16 @@ function updateRealTimeData() {
     
     dataValues.forEach(value => {
         const currentText = value.textContent;
-        
+
         if (currentText.includes('RPM')) {
-            value.textContent = (Math.floor(Math.random() * 1000) + 2000).toLocaleString();
+            const newValue = (Math.floor(Math.random() * 1000) + 2000).toLocaleString();
+            value.textContent = newValue + ' RPM';
         } else if (currentText.includes('°F')) {
-            value.textContent = (Math.floor(Math.random() * 20) + 185) + '°F';
+            const newValue = Math.floor(Math.random() * 20) + 185;
+            value.textContent = newValue + '°F';
         } else if (currentText.includes('PSI')) {
-            value.textContent = (Math.floor(Math.random() * 10) + 40) + ' PSI';
+            const newValue = Math.floor(Math.random() * 10) + 40;
+            value.textContent = newValue + ' PSI';
         }
     });
 }


### PR DESCRIPTION
## Summary
- Ensure real-time data updates append RPM, °F and PSI units so subsequent checks recognize the measurement type.

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689435446e7c8325b793c832e72d12c2