### PR TITLE
chore: merge intro lines in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # RepairBridge - Vehicle Data Management Platform
 
 A comprehensive data-access and management platform designed to bridge the gap between independent mechanics and OEM vehicle data, empowering shops with legally accessible, aggregated vehicle information, tools, and workflows.
-
 ## 🚗 Overview
 
 RepairBridge is a modern web application that provides independent auto repair shops with:


### PR DESCRIPTION
## Summary
- keep the introductory sentence in README on one line so "vehicle data" remains intact
- streamline top-of-file spacing before the Overview section

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894354e00248325b9339f923591c8c2